### PR TITLE
feat(toast): add facade

### DIFF
--- a/libs/examples/toast/src/index.ts
+++ b/libs/examples/toast/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/examples-toast.module';
+export * from './lib/toast/+state/toast.reducer';

--- a/libs/examples/toast/src/lib/examples-toast.module.ts
+++ b/libs/examples/toast/src/lib/examples-toast.module.ts
@@ -2,11 +2,16 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { ToastComponent } from './toast/toast.component';
+import { StoreModule } from '@ngrx/store';
+import { toastReducer, initialState } from './toast/+state/toast.reducer';
+import { TOAST_FEATURE_KEY } from '@pentacle/models';
 
 @NgModule({
   imports: [
     CommonModule,
-
+    StoreModule.forFeature(TOAST_FEATURE_KEY, toastReducer, {
+      initialState,
+    }),
     RouterModule.forChild([
       { path: '', pathMatch: 'full', component: ToastComponent },
     ]),

--- a/libs/examples/toast/src/lib/toast/+state/toast.facade.spec.ts
+++ b/libs/examples/toast/src/lib/toast/+state/toast.facade.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ToastFacade } from './toast.facade';
+
+describe('ToastFacade', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: ToastFacade = TestBed.get(ToastFacade);
+    expect(service).toBeTruthy();
+  });
+});

--- a/libs/examples/toast/src/lib/toast/+state/toast.facade.ts
+++ b/libs/examples/toast/src/lib/toast/+state/toast.facade.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { Store, select } from '@ngrx/store';
+import { State } from '@pentacle/models';
+import { toastQuery } from './toast.selectors';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ToastFacade {
+  isActive$: Observable<boolean> = this.store.pipe(
+    select(toastQuery.getIsActive),
+  );
+  status$: Observable<string> = this.store.pipe(select(toastQuery.getStatus));
+  constructor(private store: Store<State>) {}
+}

--- a/libs/examples/toast/src/lib/toast/+state/toast.reducer.ts
+++ b/libs/examples/toast/src/lib/toast/+state/toast.reducer.ts
@@ -1,16 +1,5 @@
 import { ToastUnion, ToastActionTypes, SuccessToast } from './toast.action';
-
-export enum ToastStatus {
-  Pending = '[Toast] Pending',
-  Success = '[Toast] Success',
-  Fail = '[Toast] Fail',
-}
-
-interface ToastState {
-  message: string;
-  status: ToastStatus;
-  isActive: boolean;
-}
+import { ToastStatus, ToastState } from '@pentacle/models';
 
 export const initialState: ToastState = {
   message: undefined,

--- a/libs/examples/toast/src/lib/toast/+state/toast.selectors.ts
+++ b/libs/examples/toast/src/lib/toast/+state/toast.selectors.ts
@@ -1,0 +1,14 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { ToastState, TOAST_FEATURE_KEY } from '@pentacle/models';
+
+const getToastState = createFeatureSelector<ToastState>(TOAST_FEATURE_KEY);
+
+const getIsActive = createSelector(getToastState, ({ isActive }) => isActive);
+
+const getStatus = createSelector(getToastState, ({ status }) => status);
+
+export const toastQuery = {
+  getToastState,
+  getIsActive,
+  getStatus,
+};

--- a/libs/examples/toast/src/lib/toast/+state/toast.spec.ts
+++ b/libs/examples/toast/src/lib/toast/+state/toast.spec.ts
@@ -9,10 +9,10 @@ import {
 
 import {
   activeToastGenerator,
-  ToastStatus,
   toastReducer,
   initialState,
 } from './toast.reducer';
+import { ToastStatus } from '@pentacle/models';
 
 describe('Toast', () => {
   describe('Actions', () => {

--- a/libs/examples/toast/src/lib/toast/toast.component.html
+++ b/libs/examples/toast/src/lib/toast/toast.component.html
@@ -1,3 +1,6 @@
 <p>
-  toast works!
+  The current state of the toast is: {{ isActive$ | async }}
+</p>
+<p>
+  The current status of the toast is: {{ status$ | async }}
 </p>

--- a/libs/examples/toast/src/lib/toast/toast.component.ts
+++ b/libs/examples/toast/src/lib/toast/toast.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { ToastFacade } from './+state/toast.facade';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'pentacle-toast',
@@ -6,7 +8,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./toast.component.scss'],
 })
 export class ToastComponent implements OnInit {
-  constructor() {}
+  isActive$: Observable<boolean> = this.toastFacade.isActive$;
+  status$: Observable<string> = this.toastFacade.status$;
+  constructor(private toastFacade: ToastFacade) {}
 
   ngOnInit() {}
 }

--- a/libs/models/src/lib/state/examples-toast.model.ts
+++ b/libs/models/src/lib/state/examples-toast.model.ts
@@ -1,0 +1,13 @@
+export const TOAST_FEATURE_KEY = 'examples-toast';
+
+export enum ToastStatus {
+  Pending = '[Toast] Pending',
+  Success = '[Toast] Success',
+  Fail = '[Toast] Fail',
+}
+
+export interface ToastState {
+  message: string;
+  status: ToastStatus;
+  isActive: boolean;
+}

--- a/libs/models/src/lib/state/index.ts
+++ b/libs/models/src/lib/state/index.ts
@@ -3,3 +3,4 @@ export * from './posts-state.model';
 export * from './router-state.model';
 export * from './tags-state.model';
 export * from './web-state.model';
+export * from './examples-toast.model';


### PR DESCRIPTION
    * add toast facade
    * add toast selectors
    * promote toast interface and enum to @pentacle/models
    * update toast component to consume toast facade

Our ngrx store will add `examples-toast` when a user visits the toast example page.


```
{
  router: {
    url: '/examples/examples-toast',
   ...
  },
  posts: {
    ...
  },
  pages: {
   ...
  },
  tags: {
   ...
  },
  'examples-toast': {
    message: undefined,
    status: '[Toast] Pending',
    isActive: false
  }
}
```
